### PR TITLE
Support --json option

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,22 +8,28 @@
 
 ```shell
 # List connections source to localhost
-lsconntrack -a 3306 11211
+lsconntrack --active 3306 11211
 ```
 
 ```shell
 # List connections localhost to destination
-lsconntrack -p 80 443
+lsconntrack --passive 80 443
 ```
 
 ### via stdin
 
 ```shell
-sudo cat /proc/net/nf_conntrack | lsconntrack --stdin -a 3306 11211
+cat /proc/net/nf_conntrack | lsconntrack --stdin --active 3306 11211
 ```
 
 ```shell
-conntrack | lsconntrack --stdin -a 3306 11211
+conntrack | lsconntrack --stdin --active 3306 11211
+```
+
+### json format
+
+```shell
+lsconntrack --json --active 3306 11211
 ```
 
 ## License

--- a/conntrack/conntrack.go
+++ b/conntrack/conntrack.go
@@ -45,19 +45,19 @@ type RawConnStat struct {
 type ConnStatByAddrPort map[string]*ConnStat
 
 type ConnStatEntries struct {
-	Active  ConnStatByAddrPort
-	Passive ConnStatByAddrPort
+	Active  ConnStatByAddrPort `json:"active"`
+	Passive ConnStatByAddrPort `json:"passive"`
 }
 
 // ConnStat represents statistics of a connection to localhost or from localhost.
 type ConnStat struct {
 	Mode                 ConnMode
-	Addr                 string
-	Port                 string
-	TotalInboundPackets  int64
-	TotalInboundBytes    int64
-	TotalOutboundPackets int64
-	TotalOutboundBytes   int64
+	Addr                 string `json:"addr"`
+	Port                 string `json:"port"`
+	TotalInboundPackets  int64  `json:"total_inbound_packets"`
+	TotalInboundBytes    int64  `json:"total_inbound_bytes"`
+	TotalOutboundPackets int64  `json:"total_outbound_packets"`
+	TotalOutboundBytes   int64  `json:"total_outbound_bytes"`
 }
 
 func parseRawConnStat(rstat *RawConnStat, localAddrs []string, ports []string) *ConnStat {


### PR DESCRIPTION
```
[y_uuki@hogehoge ~]$ sudo ./lsconntrack --json -p 80 | jq -r -M "."
{
  "10.0.0.10:80": {
    "Mode": 2,
    "addr": "10.0.0.10",
    "port": "80",
    "total_inbound_packets": 77,
    "total_inbound_bytes": 21524,
    "total_outbound_packets": 74,
    "total_outbound_bytes": 76904
  },
...
}
```